### PR TITLE
Node Restructure

### DIFF
--- a/turtlebot4_ignition_bringup/CMakeLists.txt
+++ b/turtlebot4_ignition_bringup/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ros_ign_interfaces REQUIRED)
 
 install(
-  DIRECTORY gui launch worlds
+  DIRECTORY config gui launch worlds
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
+++ b/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
@@ -1,7 +1,7 @@
 turtlebot4_node:
   ros__parameters:
     wifi:
-      interface: "wlp0s20f3"
+      interface: "wlan0"
       
       # Supported Functions:
       # Dock
@@ -30,9 +30,9 @@ turtlebot4_node:
       # button: ["SHORT_PRESS_FUNC", "LONG_PRESS_FUNC", "LONG_PRESS_DURATION_MS"]
 
     buttons:  
-      create3_1: ["Dock", "", ""]
+      create3_1: ["Dock", "Wall Follow Left", "2000"]
       create3_power: ["EStop", "Power", "3000"]
-      create3_2: ["Undock", "", ""]
+      create3_2: ["Undock", "Wall Follow Right", "2000"]
 
       hmi_1: ["Select", "", ""]
       hmi_2: ["Back", "", ""]
@@ -41,5 +41,4 @@ turtlebot4_node:
 
       # Menu entry must match a function
     menu:
-      entries: ["Dock", "Undock", "Power", "EStop", "Follow", "Help"]
-
+      entries: ["Dock", "Undock", "EStop", "Wall Follow Left", "Wall Follow Right", "Power", "Help"]

--- a/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
+++ b/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
@@ -1,0 +1,45 @@
+turtlebot4_node:
+  ros__parameters:
+    wifi:
+      interface: "wlp0s20f3"
+      
+      # Supported Functions:
+      # Dock
+      # Undock
+      # Follow
+      # Power
+      # EStop
+
+      # Menu Functions:
+      # Scroll Up
+      # Scroll Down
+      # Back
+      # Select
+      # Help
+
+      # Buttons:
+      # create3_1
+      # create3_power
+      # create3_2
+      # hmi_1
+      # hmi_2
+      # hmi_3
+      # hmi_4
+
+      # Format:
+      # button: ["SHORT_PRESS_FUNC", "LONG_PRESS_FUNC", "LONG_PRESS_DURATION_MS"]
+
+    buttons:  
+      create3_1: ["Dock", "", ""]
+      create3_power: ["EStop", "Power", "3000"]
+      create3_2: ["Undock", "", ""]
+
+      hmi_1: ["Select", "", ""]
+      hmi_2: ["Back", "", ""]
+      hmi_3: ["Scroll Up", "", ""]
+      hmi_4: ["Scroll Down", "", ""]
+
+      # Menu entry must match a function
+    menu:
+      entries: ["Dock", "Undock", "Power", "EStop", "Follow", "Help"]
+

--- a/turtlebot4_ignition_bringup/launch/ignition.launch.py
+++ b/turtlebot4_ignition_bringup/launch/ignition.launch.py
@@ -56,9 +56,6 @@ ARGUMENTS = [
     DeclareLaunchArgument('nav2', default_value='false',
                           choices=['true', 'false'],
                           description='Run nav2'),
-    DeclareLaunchArgument('node', default_value='true',
-                          choices=['true', 'false'],
-                          description='Run turtlebot4 node'),
     DeclareLaunchArgument('use_sim_time', default_value='true',
                           choices=['true', 'false'],
                           description='use_sim_time'),
@@ -130,7 +127,7 @@ def generate_launch_description():
     nav2_launch = PathJoinSubstitution(
         [pkg_turtlebot4_navigation, 'launch', 'nav2.launch.py'])
     node_launch = PathJoinSubstitution(
-        [pkg_turtlebot4_bringup, 'launch', 'robot.launch.py'])
+        [pkg_turtlebot4_ignition_bringup, 'launch', 'turtlebot4_nodes.launch.py'])
     create3_nodes_launch = PathJoinSubstitution(
         [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
     create3_ignition_nodes_launch = PathJoinSubstitution(
@@ -226,9 +223,7 @@ def generate_launch_description():
 
     turtlebot4_node = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([node_launch]),
-        launch_arguments=[('use_sim', LaunchConfiguration('use_sim')),
-                          ('model', LaunchConfiguration('model'))],
-        condition=IfCondition(LaunchConfiguration('node')),
+        launch_arguments=[('model', LaunchConfiguration('model'))]
     )
 
     # Create3 nodes

--- a/turtlebot4_ignition_bringup/launch/turtlebot4_nodes.launch.py
+++ b/turtlebot4_ignition_bringup/launch/turtlebot4_nodes.launch.py
@@ -17,6 +17,7 @@
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.conditions import LaunchConfigurationEquals
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
@@ -51,8 +52,8 @@ def generate_launch_description():
         package='turtlebot4_ignition_toolbox',
         name='turtlebot4_ignition_hmi_node',
         executable='turtlebot4_ignition_hmi_node',
-        parameters=[{'model': LaunchConfiguration('model')}],
         output='screen',
+        condition=LaunchConfigurationEquals('model', 'standard')
     )
 
     # Define LaunchDescription variable

--- a/turtlebot4_ignition_bringup/launch/turtlebot4_nodes.launch.py
+++ b/turtlebot4_ignition_bringup/launch/turtlebot4_nodes.launch.py
@@ -1,0 +1,62 @@
+# Copyright 2021 Clearpath Robotics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+
+ARGUMENTS = [
+    DeclareLaunchArgument('model', default_value='standard',
+                          choices=['standard', 'lite'],
+                          description='Turtlebot4 Model')
+]
+
+
+def generate_launch_description():
+
+    # Directories
+    pkg_turtlebot4_ignition_bringup = get_package_share_directory('turtlebot4_ignition_bringup')
+
+    # Paths
+    turtlebot4_node_yaml_file = PathJoinSubstitution(
+        [pkg_turtlebot4_ignition_bringup, 'config', 'turtlebot4_node.yaml'])
+
+    # Turtlebot4 node
+    turtlebot4_node = Node(
+        package='turtlebot4_node',
+        name='turtlebot4_node',
+        executable='turtlebot4_node',
+        parameters=[turtlebot4_node_yaml_file,
+                    {'model': LaunchConfiguration('model')}],
+        output='screen',
+    )
+
+    # Turtlebot4 Ignition Hmi node
+    turtlebot4_ignition_hmi_node = Node(
+        package='turtlebot4_ignition_toolbox',
+        name='turtlebot4_ignition_hmi_node',
+        executable='turtlebot4_ignition_hmi_node',
+        parameters=[{'model': LaunchConfiguration('model')}],
+        output='screen',
+    )
+
+    # Define LaunchDescription variable
+    ld = LaunchDescription(ARGUMENTS)
+    ld.add_action(turtlebot4_node)
+    ld.add_action(turtlebot4_ignition_hmi_node)
+    return ld

--- a/turtlebot4_ignition_toolbox/CMakeLists.txt
+++ b/turtlebot4_ignition_toolbox/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.8)
+project(turtlebot4_ignition_toolbox)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(turtlebot4_msgs REQUIRED)
+
+#Build
+
+include_directories(
+  include
+)
+
+add_library(${PROJECT_NAME}_lib
+  "src/hmi_main.cpp"
+  "src/hmi_node.cpp"
+)
+
+set(DEPENDENCIES
+  "rclcpp"
+  "rclcpp_action"
+  "rcutils"
+  "std_msgs"
+  "sensor_msgs"
+  "turtlebot4_msgs"
+)
+
+target_link_libraries(${PROJECT_NAME}_lib ${GPIOD_LIBRARY})
+
+ament_target_dependencies(${PROJECT_NAME}_lib ${DEPENDENCIES})
+
+set(EXECUTABLE_NAME "turtlebot4_ignition_hmi_node")
+
+add_executable(${EXECUTABLE_NAME} src/hmi_main.cpp)
+target_link_libraries(${EXECUTABLE_NAME} ${PROJECT_NAME}_lib)
+ament_target_dependencies(${EXECUTABLE_NAME} ${DEPENDENCIES})
+
+install(TARGETS ${EXECUTABLE_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_copyright
+  )
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+
+ament_export_include_directories(include)
+ament_package()

--- a/turtlebot4_ignition_toolbox/include/turtlebot4_ignition_toolbox/hmi_node.hpp
+++ b/turtlebot4_ignition_toolbox/include/turtlebot4_ignition_toolbox/hmi_node.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#ifndef TURTLEBOT4_IGNITION_TOOLBOX__HMI_HPP_
+#define TURTLEBOT4_IGNITION_TOOLBOX__HMI_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "turtlebot4_msgs/msg/user_button.hpp"
+#include "turtlebot4_msgs/msg/user_display.hpp"
+
+namespace turtlebot4_ignition_toolbox
+{
+
+class Hmi : public rclcpp::Node
+{
+public:
+  Hmi();
+
+private:
+  void display_subscriber_callback(const turtlebot4_msgs::msg::UserDisplay::SharedPtr msg);
+  void button_subscriber_callback(const std_msgs::msg::Int32::SharedPtr msg);
+  
+  // Publishers
+  rclcpp::Publisher<turtlebot4_msgs::msg::UserButton>::SharedPtr button_publisher_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr display_raw_publisher_;
+  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr display_selected_publisher_;
+
+  // Subscribers
+  rclcpp::Subscription<turtlebot4_msgs::msg::UserDisplay>::SharedPtr display_subscriber_;
+  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr button_subscriber_;
+};
+
+}  // namespace turtlebot4_ignition_toolbox
+
+#endif  // TURTLEBOT4_IGNITION_TOOLBOX__HMI_HPP_

--- a/turtlebot4_ignition_toolbox/include/turtlebot4_ignition_toolbox/hmi_node.hpp
+++ b/turtlebot4_ignition_toolbox/include/turtlebot4_ignition_toolbox/hmi_node.hpp
@@ -29,6 +29,8 @@
 
 namespace turtlebot4_ignition_toolbox
 {
+  
+#define DISPLAY_CHAR_PER_LINE_HEADER 21
 
 class Hmi : public rclcpp::Node
 {

--- a/turtlebot4_ignition_toolbox/package.xml
+++ b/turtlebot4_ignition_toolbox/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>turtlebot4_ignition_toolbox</name>
+  <version>0.0.0</version>
+  <description>Turtlebot4 Ignition Toolbox</description>
+  <maintainer email="rkreinin@clearpathrobotics.com">rkreinin</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rcutils</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>turtlebot4_msgs</depend>
+  <depend>ros_ign_interfaces</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/turtlebot4_ignition_toolbox/src/hmi_main.cpp
+++ b/turtlebot4_ignition_toolbox/src/hmi_main.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#include "turtlebot4_ignition_toolbox/hmi_node.hpp"
+#include <memory>
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<turtlebot4_ignition_toolbox::Hmi>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/turtlebot4_ignition_toolbox/src/hmi_node.cpp
+++ b/turtlebot4_ignition_toolbox/src/hmi_node.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Clearpath Robotics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+ */
+
+#include <string>
+#include <utility>
+
+#include "turtlebot4_ignition_toolbox/hmi_node.hpp"
+
+using turtlebot4_ignition_toolbox::Hmi;
+
+Hmi::Hmi()
+: rclcpp::Node("hmi_node")
+{
+  display_subscriber_ = create_subscription<turtlebot4_msgs::msg::UserDisplay>(
+    "/hmi/display",
+    rclcpp::SensorDataQoS(),
+    std::bind(&Hmi::display_subscriber_callback, this, std::placeholders::_1));
+
+  button_subscriber_ = create_subscription<std_msgs::msg::Int32>(
+    "/hmi/buttons/_set",
+    rclcpp::QoS(rclcpp::KeepLast(10)),
+    std::bind(&Hmi::button_subscriber_callback, this, std::placeholders::_1));
+
+  button_publisher_ = create_publisher<turtlebot4_msgs::msg::UserButton>(
+    "/hmi/buttons",
+    rclcpp::SensorDataQoS());
+
+  display_raw_publisher_ = create_publisher<std_msgs::msg::String>(
+    "/hmi/display/_raw",
+    rclcpp::QoS(rclcpp::KeepLast(10)));
+
+  display_selected_publisher_ = create_publisher<std_msgs::msg::Int32>(
+    "/hmi/display/_selected",
+    rclcpp::QoS(rclcpp::KeepLast(10)));
+}
+
+void Hmi::display_subscriber_callback(const turtlebot4_msgs::msg::UserDisplay::SharedPtr msg)
+{
+  auto raw_msg = std::make_unique<std_msgs::msg::String>();
+  auto selected_msg = std::make_unique<std_msgs::msg::Int32>();
+  selected_msg->data = msg->selected_entry;
+
+  raw_msg->data = msg->header_info;
+
+  for (size_t i = 0; i < msg->entries.size(); i++) {
+    raw_msg->data += msg->entries[i];
+  }
+
+  display_raw_publisher_->publish(std::move(raw_msg));
+  display_selected_publisher_->publish(std::move(selected_msg));
+}
+
+void Hmi::button_subscriber_callback(const std_msgs::msg::Int32::SharedPtr msg)
+{
+  auto button_msg = std::make_unique<turtlebot4_msgs::msg::UserButton>();
+
+  if (msg->data > 0) {
+    button_msg->button[msg->data - 1] = true;
+  }
+
+  button_publisher_->publish(std::move(button_msg));
+}

--- a/turtlebot4_ignition_toolbox/src/hmi_node.cpp
+++ b/turtlebot4_ignition_toolbox/src/hmi_node.cpp
@@ -55,7 +55,17 @@ void Hmi::display_subscriber_callback(const turtlebot4_msgs::msg::UserDisplay::S
   auto selected_msg = std::make_unique<std_msgs::msg::Int32>();
   selected_msg->data = msg->selected_entry;
 
-  raw_msg->data = msg->header_info;
+  std::string header = msg->ip + " " + msg->battery + "%";
+
+  if (header.length() < DISPLAY_CHAR_PER_LINE_HEADER) {
+    // Pad string
+    header.insert(header.length(), DISPLAY_CHAR_PER_LINE_HEADER - header.length(), ' ');
+  } else if (header.length() > DISPLAY_CHAR_PER_LINE_HEADER) {
+    // Remove excess characters
+    header = header.substr(0, DISPLAY_CHAR_PER_LINE_HEADER);
+  }
+
+  raw_msg->data = header;
 
   for (size_t i = 0; i < msg->entries.size(); i++) {
     raw_msg->data += msg->entries[i];


### PR DESCRIPTION
## Description

Restructured Turtlebot4 nodes.

`turtlebot4_node`:
- `turtlebot4_node` is now under the `turtlebot4` repo and controls the HMI logic.
- Display and LED states are published by `turtlebot4_node`
- `turtlebot4_node` subscribes to the Button states

`turtlebot4_base`:
- `turtlebot4_base` is now the node that runs on the Raspberry Pi of the Turtlebot4 Standard. It is not used for Turtlebot4 Lite.
- This node subscribes to Display and LED states, and publishes Button states
- This node accesses the gpio and i2c lines of the Raspberry Pi

`turtlebot4_ignition_toolbox`:
- New Package for Ignition nodes
- `turtlebot4_ignition_hmi_node` is now run when using simulator with a Standard Turtlebot4
- This node subscribes to Display states, and publishes Button states
- The node converts the received Display topic to a standard string topic that Ignition can receive
- LED state is sent directly from `turtlebot4_node` to the `ros_ign_bridge` as it does not need to be converted.

Additional changes:
- I2C bus now resets after 3 consecutive errors rather than 1 to prevent the screen from blinking.
- Replaced Wall Follow action with Wall Follow Left and Wall Follow Right
- Added new UserDisplay message

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch turtlebot4_bringup robot.launch.py
ros2 launch turtlebot4_bringup robot.launch.py model:=lite
ros2 launch turtlebot4_ignition_bringup ignition.launch.py
ros2 launch turtlebot4_ignition_bringup ignition.launch.py model:=lite
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation