### PR TITLE
Improved instructions to compile code from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ rosdep install --from-path src -yi
 
 ```bash
 source /opt/ros/galactic/setup.bash
-export IGNITION_VERSION=<installed ignition version>
+export IGNITION_VERSION=edifice
 colcon build --symlink-install
 source install/local_setup.bash
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ rosdep install --from-path src -yi
 
 ```bash
 source /opt/ros/galactic/setup.bash
+export IGNITION_VERSION=<installed ignition version>
 colcon build --symlink-install
 source install/local_setup.bash
 ```


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

## Description

One of the dependencies is ign_ros2_control, which is not synced yet. The default ignition gazebo version that is trying to find is citadel otherwise the compilation will fail, this line avoid to this issue.

```
# citadel, edifice or fortress 
export IGNITION_VERSION=<installed ignition version>
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch package launch.py
```

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation