### PR TITLE
Lingering bringup repository in package xml

### DIFF
--- a/turtlebot4_ignition_bringup/package.xml
+++ b/turtlebot4_ignition_bringup/package.xml
@@ -14,7 +14,6 @@
   <depend>turtlebot4_msgs</depend>
   <depend>turtlebot4_navigation</depend>
   <depend>turtlebot4_viz</depend>
-  <depend>turtlebot4_bringup</depend>
   <depend>turtlebot4_ignition_gui_plugins</depend>
 
   <!-- Create3 -->


### PR DESCRIPTION
This line was causing the following error. It is residual from the recent changes. 

  kscottz@woodrat:~/turtlebot4_ws$ rosdep install --from-path src -yi
  ERROR: the following packages/stacks could not have their rosdep keys resolved
  to system dependencies:
  turtlebot4_ignition_bringup: Cannot locate rosdep definition for [turtlebot4_bringup]

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes # (issue).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.



```bash
rosdep install --from-path src -yi
```

## Checklist

- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation