### PR TITLE
Removed ign_ros2_control from dependencies.repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ rosdep install --from-path src -yi
 
 ```bash
 source /opt/ros/galactic/setup.bash
+export IGNITION_VERSION=edifice
 colcon build --symlink-install
 source install/local_setup.bash
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ rosdep install --from-path src -yi
 
 ```bash
 source /opt/ros/galactic/setup.bash
-export IGNITION_VERSION=edifice
 colcon build --symlink-install
 source install/local_setup.bash
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update && sudo apt-get install ignition-edifice
 ```
 
+**Note**: `ign_ros2_control` is released but not yet sync in the Galactic stable repository. Galactic sync
+happens perodically. Meanwhile you can try to use the testing repository:
+
+#### ROS2 Testing packages
+
+Change your ROS2 package source to `ros2-testing` to get the latest updates.
+
+ - Edit `/etc/apt/sources.list.d/ros2.list`
+ - Change `http://packages.ros.org/ros2/ubuntu focal main` to `http://packages.ros.org/ros2-testing/ubuntu focal main`
+ - Run `sudo apt update`
+
 ## Build
 
 - Create a workspace if you don't already have one:

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -7,10 +7,6 @@ repositories:
     type: git
     url: https://github.com/iRobotEducation/create3_sim.git
     version: main
-  ignition-ros2-control:
-    type: git
-    url: https://github.com/ignitionrobotics/ign_ros2_control.git
-    version: galactic
   turtlebot4:
     type: git
     url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

`ign_ros2_control` is released in Galactic, this should be installed with the `rosdep` command