### PR TITLE
Fixed galactic build

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   irobot_create_msgs:
     type: git
     url: https://github.com/iRobotEducation/irobot_create_msgs.git
-    version: 1.2.2
+    version: galactic
   create3_sim:
     type: git
     url: https://github.com/iRobotEducation/create3_sim.git


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

I get this error

```bash
colossus@ipp1-0149:~/turtlebot4_ws$ colcon build --symlink-install
Starting >>> irobot_create_msgs
Starting >>> irobot_create_toolbox
Starting >>> irobot_create_description
Starting >>> ign_ros2_control
Starting >>> irobot_create_ignition_plugins
Starting >>> turtlebot4_msgs
Starting >>> turtlebot4_ignition_gui_plugins
Starting >>> turtlebot4_navigation
Finished <<< turtlebot4_navigation [1.81s]                              
Finished <<< irobot_create_description [1.96s]                          
Starting >>> turtlebot4_description
Finished <<< turtlebot4_description [2.22s]                                
Starting >>> turtlebot4_viz
Finished <<< turtlebot4_viz [1.73s]                                        
Starting >>> turtlebot4_desktop
Finished <<< irobot_create_toolbox [7.61s]                                 
Finished <<< turtlebot4_desktop [1.70s]
Finished <<< turtlebot4_msgs [11.1s]                                          
Starting >>> turtlebot4_ignition_toolbox
Finished <<< irobot_create_ignition_plugins [16.8s]                           
Finished <<< turtlebot4_ignition_gui_plugins [18.7s]                          
Finished <<< ign_ros2_control [28.2s]                                         
Starting >>> ign_ros2_control_demos
Finished <<< turtlebot4_ignition_toolbox [24.5s]                               
Finished <<< ign_ros2_control_demos [9.59s]                                    
Finished <<< irobot_create_msgs [49.3s]                         
Starting >>> irobot_create_nodes
Starting >>> irobot_create_ignition_toolbox
Starting >>> irobot_create_gazebo_plugins
Starting >>> turtlebot4_node
[Processing: irobot_create_gazebo_plugins, irobot_create_ignition_toolbox, irobot_create_nodes, turtlebot4_node]
Finished <<< irobot_create_ignition_toolbox [50.7s]
Finished <<< turtlebot4_node [53.9s]         
--- stderr: irobot_create_nodes              
In file included from /colossus/turtlebot4_ws/src/create3_sim/irobot_create_common/irobot_create_nodes/src/mock_publisher.cpp:4:
/colossus/turtlebot4_ws/src/create3_sim/irobot_create_common/irobot_create_nodes/include/irobot_create_nodes/mock_publisher.hpp:13:10: fatal error: irobot_create_msgs/msg/audio_note_vector.hpp: No such file or directory
   13 | #include "irobot_create_msgs/msg/audio_note_vector.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/mock_publisher_lib.dir/build.make:63: CMakeFiles/mock_publisher_lib.dir/src/mock_publisher.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:509: CMakeFiles/mock_publisher_lib.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:141: all] Error 2
---
Failed   <<< irobot_create_nodes [58.0s, exited with code 2]
Aborted  <<< irobot_create_gazebo_plugins [1min 5s]

Summary: 15 packages finished [1min 54s]
  1 package failed: irobot_create_nodes
  1 package aborted: irobot_create_gazebo_plugins
  1 package had stderr output: irobot_create_nodes
  8 packages not processed
```

Using the `galactic` branch this is fixed