### PR TITLE
Add 4 new Menu Entries to HMI display for "User Program" 

### DIFF
--- a/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
+++ b/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
@@ -42,7 +42,7 @@ turtlebot4_node:
 
       # Menu entry must match a function
     menu:
-      entries: ["Dock", "Undock", "My Program", "My Program 1", "My Program 2", "My Program 3", "EStop", "Wall Follow Left", "Wall Follow Right", "Power", "Help"]
+      entries: ["Dock", "Undock", "User Program 1", "User Program 2", "User Program 3", "User Program 4", "EStop", "Wall Follow Left", "Wall Follow Right", "Power", "Help"]
 
     # Controller button functions
     # Buttons:

--- a/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
+++ b/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
@@ -42,7 +42,7 @@ turtlebot4_node:
 
       # Menu entry must match a function
     menu:
-      entries: ["Dock", "Undock", "My Program", "EStop", "Wall Follow Left", "Wall Follow Right", "Power", "Help"]
+      entries: ["Dock", "Undock", "My Program", "My Program 1", "My Program 2", "My Program 3", "EStop", "Wall Follow Left", "Wall Follow Right", "Power", "Help"]
 
     # Controller button functions
     # Buttons:

--- a/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
+++ b/turtlebot4_ignition_bringup/config/turtlebot4_node.yaml
@@ -42,7 +42,7 @@ turtlebot4_node:
 
       # Menu entry must match a function
     menu:
-      entries: ["Dock", "Undock", "EStop", "Wall Follow Left", "Wall Follow Right", "Power", "Help"]
+      entries: ["Dock", "Undock", "My Program", "EStop", "Wall Follow Left", "Wall Follow Right", "Power", "Help"]
 
     # Controller button functions
     # Buttons:


### PR DESCRIPTION
## Description
This PR enables the users to launch their turtlebot4 application from HMI display by pressing "User Program 1" on HMI menu. Here we have created 4 new publishers that publish boolean values. Upon user selecting "User Program 1" button, we are publishing a bool  flag to be as True. This way user's can use this topic to subscribe in their projects as per their need and application.

![today](https://user-images.githubusercontent.com/24978535/185010515-870c914e-dc52-4d99-8383-af9d6b270f1f.png)
![presentation_1](https://user-images.githubusercontent.com/24978535/185010524-9c2a6202-957f-4597-9ce8-22c474dcf6b9.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This has been test by running:
```
ros2 topic echo /user_program_1
ros2 topic echo /user_program_2
ros2 topic echo /user_program_3
ros2 topic echo /user_program_4

```
Upon user selecting the desired User Program, the data for the corresponding topic changes to true

![Screenshot from 2022-08-16 20-59-52](https://user-images.githubusercontent.com/24978535/185010958-c6a3a77d-6b88-4581-ab80-4e2abf66d8cc.png)

```bash
# Run this command
ros2 launch turtlebot4_ignition_bringup ignition.launch.py 
```

## Checklist

- [x] I have performed a self-review of my own code and reviewed by @kscottz 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation