### PR TITLE
Fixed galactic build

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -2,11 +2,11 @@ repositories:
   irobot_create_msgs:
     type: git
     url: https://github.com/iRobotEducation/irobot_create_msgs.git
-    version: main
+    version: galactic
   create3_sim:
     type: git
     url: https://github.com/iRobotEducation/create3_sim.git
-    version: main
+    version: galactic
   turtlebot4:
     type: git
     url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
[Install Guide](https://turtlebot.github.io/turtlebot4-user-manual/software/turtlebot4_packages.html#installation-3) doesn't work at building step (colcon build).

Also: Galactic is EOL, so i guess this is not really a worthy PR