### PR TITLE
Docking Fix

### DIFF
--- a/turtlebot4_ignition_bringup/launch/turtlebot4_spawn.launch.py
+++ b/turtlebot4_ignition_bringup/launch/turtlebot4_spawn.launch.py
@@ -121,6 +121,9 @@ def generate_launch_description():
     # Spawn dock at robot position + rotational offset
     x_dock = OffsetParser(x, dock_offset_x)
     y_dock = OffsetParser(y, dock_offset_y)
+    # Spawn robot slightly clsoer to the floor to reduce the drop
+    # Ensures robot remains properly docked after the drop
+    z_robot = OffsetParser(z, -0.0025)
     # Rotate dock towards robot
     yaw_dock = OffsetParser(yaw, 3.1416)
 
@@ -148,7 +151,7 @@ def generate_launch_description():
             arguments=['-name', robot_name,
                        '-x', x,
                        '-y', y,
-                       '-z', z,
+                       '-z', z_robot,
                        '-Y', yaw,
                        '-topic', 'robot_description'],
             output='screen'


### PR DESCRIPTION
## Description

Decreased the spawn height of the turtlebot robot. I noticed that when spawning the standard turtlebot in the default worlds and the current physics max time step that the robot was unable to re-dock. 

When the simulation was played and the robot dropped, the robot would jostle, hitting the dock and rolling back just far enough that the following re-dock would fail because it wouldn't drive in close enough. By lowering the spawn location, the robot would land close enough to the dock to successfully redock later. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Spawned standard and lite robots in the `warehouse`, `depot` and `maze` worlds and repeatedly docked and undocked and checked for success. 

```bash
# Run this command
ros2 launch turtlebot4_ignition_bringup turtlebot4_ignition.launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation