### PR TITLE
Nav Double Namespace fix

### DIFF
--- a/turtlebot4_ignition_bringup/launch/turtlebot4_spawn.launch.py
+++ b/turtlebot4_ignition_bringup/launch/turtlebot4_spawn.launch.py
@@ -108,9 +108,6 @@ def generate_launch_description():
     x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
     turtlebot4_node_yaml_file = LaunchConfiguration('param_file')
-    localization = LaunchConfiguration('localization')
-    slam = LaunchConfiguration('slam')
-    nav2 = LaunchConfiguration('nav2')
 
     robot_name = GetNamespacedName(namespace, 'turtlebot4')
     dock_name = GetNamespacedName(namespace, 'standard_dock')
@@ -238,36 +235,37 @@ def generate_launch_description():
             ]
         ),
 
-        # Localization
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([localization_launch]),
-            launch_arguments=[
-                ('namespace', namespace),
-                ('use_sim_time', use_sim_time)
-            ],
-            condition=IfCondition(localization)
-        ),
-
-        # SLAM
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([slam_launch]),
-            launch_arguments=[
-                ('namespace', namespace),
-                ('use_sim_time', use_sim_time)
-            ],
-            condition=IfCondition(slam)
-        ),
-
-        # Nav2
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([nav2_launch]),
-            launch_arguments=[
-                ('namespace', namespace),
-                ('use_sim_time', use_sim_time)
-            ],
-            condition=IfCondition(nav2)
-        ),
     ])
+
+    # Localization
+    localization = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([localization_launch]),
+        launch_arguments=[
+            ('namespace', namespace),
+            ('use_sim_time', use_sim_time)
+        ],
+        condition=IfCondition(LaunchConfiguration('localization'))
+    )
+
+    # SLAM
+    slam = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([slam_launch]),
+        launch_arguments=[
+            ('namespace', namespace),
+            ('use_sim_time', use_sim_time)
+        ],
+        condition=IfCondition(LaunchConfiguration('slam'))
+    )
+
+    # Nav2
+    nav2 = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([nav2_launch]),
+        launch_arguments=[
+            ('namespace', namespace),
+            ('use_sim_time', use_sim_time)
+        ],
+        condition=IfCondition(LaunchConfiguration('nav2'))
+    )
 
     # RViz
     rviz = IncludeLaunchDescription(
@@ -282,5 +280,8 @@ def generate_launch_description():
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(param_file_cmd)
     ld.add_action(spawn_robot_group_action)
+    ld.add_action(localization)
+    ld.add_action(slam)
+    ld.add_action(nav2)
     ld.add_action(rviz)
     return ld


### PR DESCRIPTION
## Description

Don't push namespace to nav, it is handled in the nav launch files and was being applied twice. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Launch the simulation including slam, nav and/or localization in the same launch command and include a namespace. Verified that SLAM, Nav and localization all worked, specifically publishing / subscribing to the correct topics (don't have namespace duplicated). 

```bash
# Run this command
ros2 launch turtlebot4_ignition_bringup turtlebot4_ignition.launch.py nav2:=true slam:=true rviz:=true namespace:=robot1
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation