### PR TITLE
Update deprecated links

### DIFF
--- a/turtlebot4_ignition_bringup/worlds/depot.sdf
+++ b/turtlebot4_ignition_bringup/worlds/depot.sdf
@@ -14,7 +14,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Depot
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Depot
       </uri>
     </include>
 

--- a/turtlebot4_ignition_bringup/worlds/warehouse.sdf
+++ b/turtlebot4_ignition_bringup/worlds/warehouse.sdf
@@ -43,7 +43,7 @@
     <!-- Base -->
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Warehouse
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Warehouse
       </uri>
       <name>warehouse</name>
       <pose>0 0 -0.1 0 0 0</pose>
@@ -52,7 +52,7 @@
     <!-- Pallet Box Mobile -->
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/pallet_box_mobile
+        https://fuel.gazebosim.org/1.0/MovAi/models/pallet_box_mobile
       </uri>
       <name>pallet_box_0</name>
       <pose>-4 12 0.01 0 0 0</pose>
@@ -62,56 +62,56 @@
     <!-- Shelves -->
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf_big
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big
       </uri>
       <name>shelf_big_0</name>
       <pose>-8.5 -13 0 0 -0 0</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf_big
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big
       </uri>
       <name>shelf_big_1</name>
       <pose>6.5 -13 0 0 -0 0</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf_big
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big
       </uri>
       <name>shelf_big_2</name>
       <pose>-1.5 -13 0 0 -0 0</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_3</name>
       <pose>13.5 4.5 0 0 -0 0</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_4</name>
       <pose>10 4.5 0 0 -0 0</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_5</name>
       <pose>13.5 -21 0 0 -0 0</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_6</name>
       <pose>13.5 -15 0 0 -0 0</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_7</name>
       <pose>0.4 -2 0 0 -0 0</pose>
@@ -121,35 +121,35 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf_big
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big
       </uri>
       <name>shelf_big_3</name>
       <pose>3.5 9.5 0 0 0 1.57</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf_big
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf_big
       </uri>
       <name>shelf_big_4</name>
       <pose>-1.3 18.5 0 0 0 1.57</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_0</name>
       <pose>-10 21.5 0 0 -0 1.57</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_1</name>
       <pose>-7 23.6 0 0 -0 1.57</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/MovAi/models/shelf
+        https://fuel.gazebosim.org/1.0/MovAi/models/shelf
       </uri>
       <name>shelf_2</name>
       <pose>-4 21.5 0 0 -0 1.57</pose>
@@ -190,28 +190,28 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Chair
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Chair
       </uri>
       <name>chair_0</name>
       <pose>14.3 -5.5 0 0 -0 3</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Chair
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Chair
       </uri>
       <name>chair_1</name>
       <pose>14.3 -4 0 0 -0 -3</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/foldable_chair
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/foldable_chair
       </uri>
       <name>fchair_0</name>
       <pose>-11.5 6.4 0 0 -0 -1.8</pose>
     </include>
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/foldable_chair
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/foldable_chair
       </uri>
       <name>fchair1</name>
       <pose>-14 6.5 0 0 -0 1.9</pose>
@@ -221,7 +221,7 @@
 
     <include>
       <uri>
-        https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Table
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Table
       </uri>
       <name>table0</name>
       <pose>-12.7 6.5 0 0 0 0</pose>

--- a/turtlebot4_ignition_bringup/worlds/warehouse.sdf
+++ b/turtlebot4_ignition_bringup/worlds/warehouse.sdf
@@ -50,6 +50,7 @@
     </include>
 
     <!-- Pallet Box Mobile -->
+    <!--
     <include>
       <uri>
         https://fuel.gazebosim.org/1.0/MovAi/models/pallet_box_mobile
@@ -57,7 +58,7 @@
       <name>pallet_box_0</name>
       <pose>-4 12 0.01 0 0 0</pose>
       <static>true</static>
-    </include>
+    </include> -->
 
     <!-- Shelves -->
     <include>
@@ -229,13 +230,14 @@
 
     <!-- People -->
 
+    <!--
     <include>
       <uri>
       https://fuel.gazebosim.org/1.0/OpenRobotics/models/Rescue Randy Sitting
       </uri>
       <name>Person 0 - Sitting</name>
       <pose>14.65 -10 0 0 0 -1.57</pose>
-    </include> 
+    </include> -->
 
     <include>
       <uri>


### PR DESCRIPTION
## Description

Updates deprecated links to get rid of warnings and commented out models that are currently broken on the fuel server (redirects are currently broken but those models use the deprecated links within the model itself which we cannot fix).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deleted all downloaded fuel server models and then launched the simulation in both warehouse and depot worlds.

```bash
# Run this command
ros2 launch turtlebot4_ignition_bringup ignition.launch.py
ros2 launch turtlebot4_ignition_bringup ignition.launch.py world:=depot
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation