### PR TITLE
Fix Gazebo vendor packages usage

### DIFF
--- a/turtlebot4_gz_gui_plugins/CMakeLists.txt
+++ b/turtlebot4_gz_gui_plugins/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(gz_gui_vendor REQUIRED)
+find_package(gz-gui)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/turtlebot4_gz_gui_plugins/Turtlebot4Hmi/CMakeLists.txt
+++ b/turtlebot4_gz_gui_plugins/Turtlebot4Hmi/CMakeLists.txt
@@ -17,8 +17,10 @@ find_package(Qt5
 )
 
 # Find the Gz gui library
-find_package(gz-gui8 REQUIRED)
-find_package(gz-common5 REQUIRED)
+find_package(gz_gui_vendor REQUIRED)
+find_package(gz-gui REQUIRED)
+find_package(gz_common_vendor REQUIRED)
+find_package(gz-common REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GZ-GUI_CXX_FLAGS}")
 
@@ -39,6 +41,7 @@ link_directories(
 )
 
 # Generate examples
+# MOC parsing is broken on Ionic: https://github.com/gazebosim/gz-msgs/issues/463
 add_library(Turtlebot4Hmi SHARED ${headers_MOC}
 Turtlebot4Hmi.cc
   ${resources_rcc}


### PR DESCRIPTION
## Description

I was testing the use of upcoming Gazebo Ionic with current jazzy branch (it is using Gazebo Harmonic by default) and found that the use of the new vendor packages could be improved and corrected according to https://gazebosim.org/docs/ionic/ros2_gz_vendor_pkgs/#cmakelists-txt-for-building-with-gazebo-vendor-packages

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I test the compilation using Gazebo Ionic in a docker container. Note the the use of Ionic is still affected by https://github.com/gazebosim/gz-msgs/issues/463 so compilation can not succeed even with this PR.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation