### PR TITLE
Start simulation when launching Ignition

### DIFF
--- a/turtlebot4_ignition_bringup/launch/ignition.launch.py
+++ b/turtlebot4_ignition_bringup/launch/ignition.launch.py
@@ -83,6 +83,7 @@ def generate_launch_description():
         launch_arguments=[
             ('ign_args', [LaunchConfiguration('world'),
                           '.sdf',
+                          ' -r',
                           ' -v 4',
                           ' --gui-config ',
                           PathJoinSubstitution(


### PR DESCRIPTION
## Description

Make Ignition start the simulation when it is launched.

This seems to fix issue #81 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally on my laptop, with ROS Humble and Ubuntu 22.04

```bash
# Run this command
ros2 launch turtlebot4_ignition_bringup turtlebot4_ignition.launch.py 
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation